### PR TITLE
Revert some Makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,9 @@ brahma: bootstrap
 	@cp $(TOPDIR)/$(LOADER)/output/$(OUTPUT_N).3dsx $(OUTPUT).3dsx
 	@cp $(TOPDIR)/$(LOADER)/output/$(OUTPUT_N).smdh $(OUTPUT).smdh
 
-cakehax: gateway
+cakehax: $(OUTPUT_D)
+	@[ -d $(BUILD) ] || mkdir -p $(BUILD)
+	@make --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile EXEC_METHOD=GATEWAY
 	@make dir_out=$(OUTPUT_D) name=$(TARGET).dat -C CakeHax bigpayload
 	dd if=$(OUTPUT).bin of=$(OUTPUT).dat bs=512 seek=160
 	


### PR DESCRIPTION
We don't want to build the Launcher.dat when building CakeHax Decrypt9.dat. Sorry about the tiny pull request, but it will be pretty easy to review for sure.

And yup, that was my mistake :).
