### PR TITLE
Revert NAND_SWITCH commit

### DIFF
--- a/resources/AppInfo
+++ b/resources/AppInfo
@@ -1,3 +1,3 @@
-APP_TITLE = Decrypt9
+APP_TITLE = Decrypt9UI
 APP_DESCRIPTION = Xorpad Generation + Other tools / GUI mod
 APP_AUTHOR = Archshift with mods by Shadowtrance & d0k3

--- a/source/common.h
+++ b/source/common.h
@@ -26,10 +26,10 @@
        __typeof__ (b) _b = (b); \
        _a < _b ? _a : _b; })
     
-// customizations
+// customizations - careful with DANGER_ZONE, USE_EMUNAND still needs testing
 #define DANGER_ZONE
-#define NAND_SWITCH
 #define WORKDIR "/Decrypt9"
+// #define USE_EMUNAND
 
 inline char* strupper(const char* str) {
     char* buffer = (char*)malloc(strlen(str) + 1);

--- a/source/decryptor/decryptor.c
+++ b/source/decryptor/decryptor.c
@@ -4,7 +4,6 @@
 #include "fs.h"
 #include "draw.h"
 #include "platform.h"
-#include "fatfs/sdmmc.h"
 #include "decryptor/decryptor.h"
 #include "decryptor/crypto.h"
 #include "decryptor/features.h"
@@ -16,12 +15,11 @@
 #define NAND_SECTOR_SIZE    0x200
 #define SECTORS_PER_READ    (BUFFER_MAX_SIZE / NAND_SECTOR_SIZE)
 
-#ifdef NAND_SWITCH
-    #define sdmmc_nand_readsectors  sdmmc_uni_readsectors
-    #define sdmmc_nand_writesectors sdmmc_uni_writesectors
-    int (*sdmmc_uni_readsectors)(u32, u32, u8*);
-    int (*sdmmc_uni_writesectors)(u32, u32, u8*);
+#ifdef USE_EMUNAND
+#define sdmmc_nand_readsectors  sdmmc_sdcard_readsectors
+#define sdmmc_nand_writesectors sdmmc_sdcard_writesectors
 #endif
+
 
 // From https://github.com/profi200/Project_CTR/blob/master/makerom/pki/prod.h#L19
 static const u8 common_keyy[6][16] = {
@@ -43,21 +41,6 @@ static PartitionInfo partitions[] = {
     { "CTRNAND", {0xE9, 0x00, 0x00, 0x43, 0x54, 0x52, 0x20, 0x20}, 0x0B95CA00, 0x2F3E3600, 0x4, AES_CNT_CTRNAND_MODE }, // O3DS
     { "CTRNAND", {0xE9, 0x00, 0x00, 0x43, 0x54, 0x52, 0x20, 0x20}, 0x0B95AE00, 0x41D2D200, 0x5, AES_CNT_CTRNAND_MODE }  // N3DS
 };
-
-#ifdef NAND_SWITCH
-u32 SetNand(bool use_emunand)
-{
-    if (use_emunand) {
-        sdmmc_uni_readsectors = sdmmc_sdcard_readsectors;
-        sdmmc_uni_writesectors = sdmmc_sdcard_writesectors;
-    } else {
-        sdmmc_uni_readsectors = sdmmc_nand_readsectors;
-        sdmmc_uni_writesectors = sdmmc_nand_writesectors;
-    }
-    
-    return 0;
-}
-#endif
 
 u32 DecryptBuffer(DecryptBufferInfo *info)
 {
@@ -886,7 +869,7 @@ u32 FirmPadgen()
 {
     u32 size_mb = (partitions[3].size + partitions[4].size + (1024 * 1024) - 1) / (1024 * 1024);
     Debug("Creating FIRM0FIRM1 xorpad. Size (MB): %u", size_mb);
-    Debug("Filename: firm0.xorpad");
+    Debug("Filename: firm0firm1.xorpad");
 
     PadInfo padInfo = {
         .keyslot = partitions[3].keyslot,

--- a/source/draw.c
+++ b/source/draw.c
@@ -137,11 +137,9 @@ void DrawSplash(const char* splash_file, u32 use_top_screen) {
     FileClose();
 }
 
-void DrawSplashLogo(const char* msg)
+void DrawSplashLogo()
 {
     DrawSplash("menuTOP.bin", 1); // top screen
-    if (msg != NULL)
-    DrawStringF(20, 162, FONT_M_COLOR, BG_M_COLOR, "%s", msg);
     #ifdef WORKDIR
     DrawStringF(50, 210, FONT_M_COLOR, BG_M_COLOR, "Working directory: %s", WORKDIR);
     #endif

--- a/source/draw.h
+++ b/source/draw.h
@@ -53,4 +53,4 @@ void Debug(const char *format, ...);
 void ShowProgress(u32 current, u32 total);
 
 void DrawSplash(const char* splash_file, u32 use_top_screen);
-void DrawSplashLogo(const char* msg);
+void DrawSplashLogo();

--- a/source/menu.c
+++ b/source/menu.c
@@ -7,12 +7,6 @@
 #define GFX_DONE        "done.bin"
 #define GFX_FAILED      "failed.bin"
 
-#ifdef NAND_SWITCH
-#define LOGO_MSG ((use_emunand) ? "Current NAND (X): EmuNAND" : "Current NAND (X): SysNAND")
-static bool use_emunand = false;
-#else
-#define LOGO_MSG NULL
-#endif
 
 void ProcessEntry(MenuEntry* entry)
 {
@@ -32,9 +26,6 @@ void ProcessEntry(MenuEntry* entry)
     
     DebugSetTitle(entry->longTitle);
     DebugClear();
-    #ifdef NAND_SWITCH
-    SetNand(use_emunand);
-    #endif
     if (entry->function() == 0) {
         Debug("%s: %s!", entry->shortTitle, "succeeded");
         DrawSplash(GFX_DONE, 0);
@@ -44,7 +35,7 @@ void ProcessEntry(MenuEntry* entry)
     }
     Debug("Press B to exit");
     while (!(InputWait() & BUTTON_B));
-    DrawSplashLogo(LOGO_MSG);
+    DrawSplashLogo();
 }
 
 u32 ProcessMenu(MenuInfo* info, u32 nMenus)
@@ -53,7 +44,7 @@ u32 ProcessMenu(MenuInfo* info, u32 nMenus)
     u32 menu_idx = 0;
     u32 pad_state;
     
-    DrawSplashLogo(LOGO_MSG);
+    DrawSplashLogo();
     
     while(true) {
         // draw bottom graphics
@@ -78,12 +69,6 @@ u32 ProcessMenu(MenuInfo* info, u32 nMenus)
         } else if (pad_state & BUTTON_A) { // process action
             ProcessEntry(&(menu->entries[menu_idx]));
         }
-        #ifdef NAND_SWITCH
-        else if (pad_state & BUTTON_X) { // switch NAND
-            use_emunand = !use_emunand;
-            DrawSplashLogo(LOGO_MSG);
-        }
-        #endif
     }
     
     return 0;


### PR DESCRIPTION
This doesn't work properly - so we do this in a different way for now, and if it works we'll come up with a better implementation.

EmuNAND is now enabled via #define USE_EMUNAND in common.h. Also, fixed one small typo in FirmPadgen().

If you want to make a special release for EmuNAND, I'd also suggest you change the APP_TITLE for just this release in /resources/AppInfo
